### PR TITLE
demofile: walk through the file on DemoFile init

### DIFF
--- a/src/demofile.cc
+++ b/src/demofile.cc
@@ -12,15 +12,31 @@ Demofile::Demofile(std::string fn)
         = std::ifstream(filename, std::ios_base::in | std::ios_base::binary);
 
     if (!fileHandle.is_open()) {
-        throw std::ios_base::failure("unable to open file");
+        std::string errmsg = "unable to open file: '" + filename + "'";
+        throw std::ios_base::failure(errmsg);
     }
 
     read_header();
+    print_game_details();
+
+    DemoData *demo_blob = read_next_blob();
+    while (demo_blob->cmd != DEMO_STOP) {
+        std::cerr << "CMD TYPE: " << (int32_t)demo_blob->cmd << std::endl;
+        std::cerr << "CMD TICK: " << demo_blob->tick << std::endl;
+
+        delete demo_blob->blob;
+        delete demo_blob;
+
+        demo_blob = read_next_blob();
+    }
+
+    delete demo_blob->blob;
+    delete demo_blob;
 }
 
-Demofile::~Demofile() { fileHandle.close(); }
+Demofile::~Demofile(void) { fileHandle.close(); }
 
-void Demofile::read_header()
+void Demofile::read_header(void)
 {
     fileHandle.read((char *)&header, sizeof(demoheader_t));
     if (!fileHandle) {
@@ -29,7 +45,7 @@ void Demofile::read_header()
     check_header();
 }
 
-void Demofile::check_header()
+void Demofile::check_header(void)
 {
     if (strcmp(DEMO_HEADER_ID, header.demofilestamp)) {
         throw std::runtime_error(std::string("wrong demo header ID: ")
@@ -42,9 +58,108 @@ void Demofile::check_header()
     }
 }
 
-void Demofile::print_game_details()
+void Demofile::read_cmd_header(DemoData *d)
 {
+    fileHandle.read((char *)&d->cmd, sizeof(unsigned char));
+    if (d->cmd <= 0) {
+        throw std::runtime_error("No end tag in demo file");
+    }
 
+    if (d->cmd > DEMO_LASTCMD) {
+        throw std::runtime_error("Unknown command in demo file");
+    }
+
+    fileHandle.read((char *)&d->tick, sizeof(int32_t));
+    fileHandle.read((char *)&d->playerSlot, sizeof(unsigned char));
+
+    if (!fileHandle) {
+        throw std::runtime_error("Couldn't read CMD header successfully");
+    }
+}
+
+void Demofile::read_cmd_info(democmdinfo_t &info)
+{
+    fileHandle.read((char *)&info, sizeof(democmdinfo_t));
+
+    if (!fileHandle) {
+        throw std::runtime_error("Couldn't read CMD info successfully");
+    }
+}
+
+void Demofile::read_blob(DemoData *cmd, bool skip)
+{
+    /* FIXME: if skip set, only use fseek to jump over a blob */
+    fileHandle.read((char *)&cmd->blob_size, sizeof(int32_t));
+
+    /* FIXME: take care of possible exceptions */
+    cmd->blob = new char[cmd->blob_size];
+
+    fileHandle.read(cmd->blob, cmd->blob_size);
+    if (!fileHandle) {
+        std::string reason;
+        if (fileHandle.eofbit)
+            reason = "reached eof";
+        else if (fileHandle.badbit)
+            reason = "memory shortage of ifstream except";
+        else if (fileHandle.failbit)
+            reason = "total crap";
+        throw std::runtime_error(
+            std::string("Couldn't read a blob successfully: ") + reason);
+    }
+}
+
+DemoData *Demofile::read_next_blob(void)
+{
+    DemoData *blob = new DemoData;
+    blob->blob = NULL;
+
+    read_cmd_header(blob);
+
+    switch (blob->cmd) {
+    case DEMO_SYNCTICK:
+    case DEMO_STOP:
+        break;
+
+    case DEMO_CONSOLECMD:
+        read_blob(blob);
+        break;
+
+    case DEMO_DATATABLES:
+        read_blob(blob);
+        break;
+
+    case DEMO_STRINGTABLES:
+        read_blob(blob);
+        break;
+
+    case DEMO_USERCMD:
+        int32_t dummy; // FIXME: use fseek later to skip dummy data
+        fileHandle.read((char *)&dummy, sizeof(int32_t));
+        read_blob(blob);
+        break;
+
+    case DEMO_SIGNON:
+    case DEMO_PACKET: {
+        int32_t dummy_seq;
+        democmdinfo_t demoinfo;
+        read_cmd_info(demoinfo);
+
+        // TODO: read sequence function
+        fileHandle.read((char *)&dummy_seq, sizeof(int32_t));
+        fileHandle.read((char *)&dummy_seq, sizeof(int32_t));
+
+        read_blob(blob);
+    } break;
+
+    default:
+        break;
+    }
+
+    return blob;
+}
+
+void Demofile::print_game_details(void)
+{
     std::cout << "ID: " << header.demofilestamp
               << "; PROTOCOL: " << header.demoprotocol << std::endl
               << "========================" << std::endl

--- a/src/demofile.h
+++ b/src/demofile.h
@@ -13,6 +13,43 @@
 #define DEMO_HEADER_ID "HL2DEMO"
 #define DEMO_PROTOCOL 4
 
+#define DEMO_RECORD_BUFFER_SIZE                                                \
+    (2 * 1024 * 1024) // temp buffer big enough to fit both string tables and
+                      // server classes
+#define NET_MAX_PAYLOAD (262144 - 4) // largest message we can send in bytes
+
+#define FDEMO_NORMAL 0
+#define FDEMO_USE_ORIGIN2 (1 << 0)
+#define FDEMO_USE_ANGLES2 (1 << 1)
+#define FDEMO_NOINTERP (1 << 2) // don't interpolate between this an last view
+
+#define MAX_SPLITSCREEN_CLIENTS 2
+
+// Demo messages
+enum {
+    // it's a startup message, process as fast as possible
+    DEMO_SIGNON = 1,
+    // it's a normal network packet that we stored off
+    DEMO_PACKET,
+    // sync client clock to demo tick
+    DEMO_SYNCTICK,
+    // console command
+    DEMO_CONSOLECMD,
+    // user input command
+    DEMO_USERCMD,
+    // network data tables
+    DEMO_DATATABLES,
+    // end of time.
+    DEMO_STOP,
+    // a blob of binary data understood by a callback function
+    DEMO_CUSTOMDATA,
+
+    DEMO_STRINGTABLES,
+
+    // Last command
+    DEMO_LASTCMD = DEMO_STRINGTABLES
+};
+
 struct demoheader_t {
     char demofilestamp[8]; // Should be HL2DEMO
     int32_t demoprotocol; // Should be DEMO_PROTOCOL
@@ -27,15 +64,137 @@ struct demoheader_t {
     int32_t signonlength; // length of sigondata in bytes
 };
 
+struct QAngle {
+    float x, y, z;
+    void Init(void) { x = y = z = 0.0f; }
+    void Init(float _x, float _y, float _z)
+    {
+        x = _x;
+        y = _y;
+        z = _z;
+    }
+};
+
+struct Vector {
+    float x, y, z;
+    void Init(void) { x = y = z = 0.0f; }
+    void Init(float _x, float _y, float _z)
+    {
+        x = _x;
+        y = _y;
+        z = _z;
+    }
+};
+
+struct democmdinfo_t {
+    democmdinfo_t(void) {}
+
+    struct Split_t {
+        int32_t flags;
+
+        // original origin/viewangles
+        Vector viewOrigin;
+        QAngle viewAngles;
+        QAngle localViewAngles;
+
+        // Resampled origin/viewangles
+        Vector viewOrigin2;
+        QAngle viewAngles2;
+        QAngle localViewAngles2;
+
+        Split_t(void)
+        {
+            flags = FDEMO_NORMAL;
+            viewOrigin.Init();
+            viewAngles.Init();
+            localViewAngles.Init();
+
+            // Resampled origin/angles
+            viewOrigin2.Init();
+            viewAngles2.Init();
+            localViewAngles2.Init();
+        }
+
+        Split_t &operator=(const Split_t &src)
+        {
+            if (this == &src)
+                return *this;
+
+            flags = src.flags;
+            viewOrigin = src.viewOrigin;
+            viewAngles = src.viewAngles;
+            localViewAngles = src.localViewAngles;
+            viewOrigin2 = src.viewOrigin2;
+            viewAngles2 = src.viewAngles2;
+            localViewAngles2 = src.localViewAngles2;
+
+            return *this;
+        }
+
+        const Vector &GetViewOrigin(void)
+        {
+            if (flags & FDEMO_USE_ORIGIN2) {
+                return viewOrigin2;
+            }
+            return viewOrigin;
+        }
+
+        const QAngle &GetViewAngles(void)
+        {
+            if (flags & FDEMO_USE_ANGLES2) {
+                return viewAngles2;
+            }
+            return viewAngles;
+        }
+        const QAngle &GetLocalViewAngles(void)
+        {
+            if (flags & FDEMO_USE_ANGLES2) {
+                return localViewAngles2;
+            }
+            return localViewAngles;
+        }
+
+        void Reset(void)
+        {
+            flags = 0;
+            viewOrigin2 = viewOrigin;
+            viewAngles2 = viewAngles;
+            localViewAngles2 = localViewAngles;
+        }
+    };
+
+    void Reset(void)
+    {
+        for (int i = 0; i < MAX_SPLITSCREEN_CLIENTS; ++i) {
+            u[i].Reset();
+        }
+    }
+
+    Split_t u[MAX_SPLITSCREEN_CLIENTS];
+};
+
+struct DemoData {
+    int32_t tick;
+    unsigned char cmd;
+    unsigned char playerSlot;
+
+    int32_t blob_size;
+    char *blob;
+};
+
 class Demofile {
 public:
     Demofile(std::string fn);
-    ~Demofile();
-    void print_game_details();
+    ~Demofile(void);
+    void print_game_details(void);
 
 private:
-    void read_header();
-    void check_header();
+    void read_header(void);
+    void read_cmd_header(DemoData *);
+    void read_cmd_info(democmdinfo_t &);
+    void read_blob(DemoData *cmd, bool skip = false);
+    DemoData *read_next_blob(void);
+    void check_header(void);
 
 private:
     std::string filename;


### PR DESCRIPTION
This commit adds the possibility for the program to walk through
the whole input binary file, listing the blobs it sees.

FIXED: some methods were declared for an unknown number of parameters,
that is now fixed.