### PR TITLE
Removing of output duplicity

### DIFF
--- a/src/demofile.cc
+++ b/src/demofile.cc
@@ -16,7 +16,6 @@ Demofile::Demofile(std::string fn)
     }
 
     read_header();
-    print_game_details();
 
     DemoData *demo_blob = read_next_blob();
     while (demo_blob->cmd != DEMO_STOP) {


### PR DESCRIPTION
label: bug

Function print_game_details() is public method of Demofile class.
I personally prefer if we print output after parsing. So I deleted
printing which was invocated internally during parsing.